### PR TITLE
Beautify json responses to be multiline.

### DIFF
--- a/client/client_request.py
+++ b/client/client_request.py
@@ -1,3 +1,5 @@
+import json
+
 from backend_http.do_request import (
     InvalidUrl,
     HttpVerbNotImplemented,
@@ -25,7 +27,8 @@ def client_request(http_verb, url):
 def beautify_response(response):
 
     status_code = 'Status code: {}'.format(response.status_code)
-    response_text = 'Response:\n\n{}'.format(response.text)
+    beautiful_json = beautify_json_dict(response.json())
+    response_text = 'Response:\n\n{}'.format(beautiful_json)
 
     output_response = '{status_code}\n{response_text}'.format(
         status_code=status_code,
@@ -33,3 +36,8 @@ def beautify_response(response):
     )
 
     return output_response
+
+
+def beautify_json_dict(original_json):
+
+    return json.dumps(original_json, indent=4)

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -6,7 +6,11 @@ from backend_http.do_request import (
     InvalidUrl,
     HttpVerbNotImplemented,
 )
-from client.client_request import client_request
+from client.client_request import(
+    beautify_json_dict,
+    beautify_response,
+    client_request,
+)
 
 
 class TestClientMapsExceptionsToText:
@@ -36,18 +40,16 @@ class TestClientMapsExceptionsToText:
 class TestClientGetMapsRequestResponses:
 
     @mock.patch('client.client_request.do_request')
-    def test_it_maps_response_to_text(self, mock_do_request):
+    @mock.patch('client.client_request.beautify_response')
+    def test_it_maps_response_to_text(
+        self,
+        mock_beautify_response,
+        mock_do_request,
+    ):
 
-        mock_attrs = {
-            'status_code': 200,
-            'json.return_value': {
-                'lemon': 'champ',
-                'magic': True,
-            },
-            'text': '{"lemon": "champ", "magic": true}',
-        }
-        mock_response = mock.MagicMock(**mock_attrs)
-        mock_do_request.return_value = mock_response
+        response_mock = mock.MagicMock()
+        mock_do_request.return_value = response_mock
+        mock_beautify_response.return_value = 'beautiful response ☕️'
 
         response = client_request('get', 'http://lemon.com/api/resource/')
 
@@ -55,8 +57,48 @@ class TestClientGetMapsRequestResponses:
             'get',
             'http://lemon.com/api/resource/',
         )
-        assert response == (
+        mock_beautify_response.assert_called_once_with(response_mock)
+        assert response == 'beautiful response ☕️'
+
+
+class TestBeautifyResponse:
+
+    @mock.patch('client.client_request.beautify_json_dict')
+    def test_it_formats_the_response(self, mock_beautify_json_dict):
+
+        mock_attrs = {
+            'status_code': 200,
+        }
+        mock_response = mock.MagicMock(**mock_attrs)
+        mock_beautify_json_dict.return_value = 'beautiful json 🍋'
+
+        expected_beautified = (
             'Status code: 200'
             '\nResponse:'
-            '\n\n{"lemon": "champ", "magic": true}'
+            '\n\nbeautiful json 🍋'
         )
+
+        assert beautify_response(mock_response) == expected_beautified
+
+
+class TestBeautifyJsonDict:
+
+    def test_it_formats_a_dict_to_json_string(self):
+
+        original_json = {
+            'lemon': 'champ',
+            'magic': True,
+            'float': 0.233,
+            'integer': 43,
+        }
+
+        expected_beautified = (
+            '{'
+            '\n    "lemon": "champ",'
+            '\n    "magic": true,'
+            '\n    "float": 0.233,'
+            '\n    "integer": 43'
+            '\n}'
+        )
+
+        assert beautify_json_dict(original_json) == expected_beautified


### PR DESCRIPTION
Formatting improvement for `beautify_response`, not the `beautify_json_dict` generates a multiline output to make the result easier for reading.